### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/proje.py
+++ b/proje.py
@@ -23,6 +23,7 @@ import unicodedata
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 import difflib
+import logging
 
 import pdfplumber  # pip install pdfplumber
 from fastapi import Body, FastAPI, Request
@@ -716,7 +717,8 @@ def ask(body: dict = Body(default={})):
         return JSONResponse({"answer": ans, "sources": [src], "error": None})
 
     except Exception as e:
-        return JSONResponse({"answer": "", "sources": [], "error": f"{type(e).__name__}: {e}"})
+        logging.exception("Exception during /ask endpoint processing")
+        return JSONResponse({"answer": "", "sources": [], "error": "Beklenmeyen bir hata oluştu."})
 
 @app.post("/reindex")
 def reindex():


### PR DESCRIPTION
Potential fix for [https://github.com/Yigtwxx/FiratUniversityChatbot/security/code-scanning/1](https://github.com/Yigtwxx/FiratUniversityChatbot/security/code-scanning/1)

To remedy the information exposure, modify the exception handler in the `/ask` endpoint to return a generic error message to the user, rather than echoing exception details. Internal details, such as exception messages or types, should be logged only on the server side for debugging purposes. Specifically:
- Change line 719 (the exception handler block in the `/ask` endpoint) so that the response always returns a generic error message, e.g., `"Beklenmeyen bir hata oluştu."` (A generic Turkish message: "An unexpected error occurred"), with `error` set to `None` or the generic string.
- Optionally, add a server-side logging statement for the full exception using the standard `logging` module if not already present, so developers can still inspect the root cause.
- The changes are localized to the `/ask` endpoint: lines 718-719 in `proje.py`.
- If logging will be added, ensure that the `logging` module is imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
